### PR TITLE
feat: endpoint for start process

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ nexus
 │    ├── update(<userId>, <userParamsObj>)
 │    └── notifications
 │         └── putAll(<notificationObj>)
+├── command
+│    └── device
+│         └── process
+│               └── start-process
 ├── datapoints
 │    └──get(<processId>, <reporterFctId>, <params>)
 ├── device
@@ -102,7 +106,6 @@ nexus
 |    └── device
 |         └── deleteMany(<deviceId>)
 ├── process
-|    ├── get(<processId>)
 |    └── functionality
 |         └── image
 |              ├── create
@@ -112,6 +115,7 @@ nexus
      |    ├── setCredentials
      |    └── validateAuthorization
      ├── process
+    `|    ├── get(<processId>)
      |    └── functionality
      |         └── image
      |              ├── createFromUri

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const { Amplify } = require('aws-amplify')
 
 const Auth = require('./src/auth')
 const User = require('./src/user')
+const Command = require('./src/command')
 const Device = require('./src/device')
 const Log = require('./src/log')
 const Process = require('./src/process')
@@ -29,6 +30,7 @@ const connect = customConnectionOpts => {
 module.exports = {
   auth: Auth,
   user: User,
+  command: Command,
   device: Device,
   log: Log,
   process: Process,

--- a/src/amplify/configGenerator.js
+++ b/src/amplify/configGenerator.js
@@ -22,6 +22,11 @@ const getAPIEndPointsConfig = ({ ENV, AWS_REGION }) => ({
         region: AWS_REGION,
       },
       {
+        name: 'command',
+        endpoint: `https://api-${ENV}.ospin-services.com/commands/`,
+        region: AWS_REGION,
+      },
+      {
         name: 'device',
         endpoint: `https://api-${ENV}.ospin-services.com/devices/`,
         region: AWS_REGION,

--- a/src/command/device/index.js
+++ b/src/command/device/index.js
@@ -1,0 +1,5 @@
+const process = require('./process')
+
+module.exports = {
+  process,
+}

--- a/src/command/device/process/index.js
+++ b/src/command/device/process/index.js
@@ -1,0 +1,5 @@
+const startProcess = require('./startProcess')
+
+module.exports = {
+  startProcess,
+}

--- a/src/command/device/process/startProcess.js
+++ b/src/command/device/process/startProcess.js
@@ -1,0 +1,12 @@
+const { API } = require('aws-amplify')
+
+const serializeAxiosResponse = require('utils/serializeAxiosResponse')
+const { DEFAULT_REQ_OPTS } = require('utils/defaultReqOpts')
+
+module.exports = serializeAxiosResponse(
+  (deviceId, processId) => API.post(
+    'command',
+    `devices/${deviceId}/processes/${processId}/start-process`,
+    { body: {}, ...DEFAULT_REQ_OPTS },
+  ),
+)

--- a/src/command/index.js
+++ b/src/command/index.js
@@ -1,0 +1,5 @@
+const device = require('./device')
+
+module.exports = {
+  device,
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -23,6 +23,13 @@ describe('nexus', () => {
       signIn: 'function',
       signOut: 'function',
     },
+    command: {
+      device: {
+        process: {
+          startProcess: 'function',
+        },
+      },
+    },
     dataPoints: {
       get: 'function',
       requestReporterFctData: 'function',

--- a/test/src/amplify/configGenerator.test.js
+++ b/test/src/amplify/configGenerator.test.js
@@ -22,6 +22,11 @@ describe('createConfig', () => {
               region: AWS_REGION,
             },
             {
+              name: 'command',
+              endpoint: `https://api-${ENV}.ospin-services.com/commands/`,
+              region: AWS_REGION,
+            },
+            {
               endpoint: `https://api-${ENV}.ospin-services.com/devices/`,
               name: 'device',
               region: AWS_REGION,

--- a/test/src/command/device/process/startProcess.test.js
+++ b/test/src/command/device/process/startProcess.test.js
@@ -1,0 +1,67 @@
+const faker = require('faker')
+const startProcess = require('command/device/process/startProcess')
+const { API } = require('aws-amplify')
+const { DEFAULT_REQ_OPTS } = require('utils/defaultReqOpts')
+
+describe('create Process Functionality Image', () => {
+
+  afterAll(() => { jest.restoreAllMocks() })
+
+  beforeEach(() => {
+    jest.spyOn(API, 'post').mockImplementation(args => args)
+  })
+
+  const processId = faker.datatype.uuid()
+  const deviceId = faker.datatype.uuid()
+
+  it('calls amplifys API.post with the expected args', async () => {
+
+    startProcess(deviceId, processId)
+
+    expect(API.post).toHaveBeenCalledWith(
+      'command',
+      `devices/${deviceId}/processes/${processId}/start-process`,
+      { body: {}, ...DEFAULT_REQ_OPTS },
+
+    )
+  })
+
+  describe('on success', () => {
+
+    beforeEach(() => {
+      jest.spyOn(API, 'post').mockImplementation(() => ({ data: 'success!', status: 200 }))
+    })
+
+    it('should respond with the data ,the status code and success=true', async () => {
+      const resp = await startProcess({})
+
+      expect(resp).toStrictEqual(expect.objectContaining({
+        success: true,
+        data: 'success!',
+        error: null,
+        errorMsg: null,
+        status: 200,
+      }))
+    })
+
+    describe('on failure', () => {
+
+      beforeEach(() => {
+        jest.spyOn(API, 'post').mockImplementation(() => { throw new Error() })
+      })
+
+      it('should repond with the error message,the status code and success=false', async () => {
+
+        const resp = await startProcess({})
+
+        expect(resp).toStrictEqual(expect.objectContaining({
+          success: false,
+          data: null,
+          error: new Error(),
+          errorMsg: '',
+          status: null,
+        }))
+      })
+    })
+  })
+})


### PR DESCRIPTION
end to end tesed with the hambda ticket 

Endpoint response
```
felix@felix-XPS-13-7390:~/code/work/dummyReactor$ node startProcess.js 
{
  success: true,
  status: 200,
  data: { status: 'dispatched' },
  error: null,
  errorMsg: null
}
````

```
