### PR TITLE
fix: add query params to device user list

### DIFF
--- a/src/user/device/list.js
+++ b/src/user/device/list.js
@@ -14,5 +14,5 @@ const { DEFAULT_REQ_OPTS } = require('../../utils/defaultReqOpts')
  */
 
 module.exports = serializeAxiosResponse(
-  ({ userId }) => API.get('user', `${userId}/devices`, DEFAULT_REQ_OPTS),
+  ({ userId, queryStringParameters }) => API.get('user', `${userId}/devices`, { queryStringParameters, ...DEFAULT_REQ_OPTS }),
 )

--- a/test/src/user/device/list.test.js
+++ b/test/src/user/device/list.test.js
@@ -9,6 +9,9 @@ describe('list', () => {
 
   const params = {
     userId: faker.datatype.uuid(),
+    queryStringParameters: {
+      skip: 5,
+    },
   }
 
   afterAll(() => { jest.restoreAllMocks() })
@@ -20,7 +23,7 @@ describe('list', () => {
     expect(API.get).toHaveBeenCalledWith(
       'user',
       `${params.userId}/devices`,
-      DEFAULT_REQ_OPTS,
+      { queryStringParameters: { skip: 5 }, ...DEFAULT_REQ_OPTS },
     )
   })
 


### PR DESCRIPTION
patch: add query params to device user list

- closes #145